### PR TITLE
Disable lzma

### DIFF
--- a/build-cmd.sh
+++ b/build-cmd.sh
@@ -96,21 +96,6 @@ pushd "$TOP/$SOURCE_DIR"
         ;;
 
         linux*)
-            # Linux build environment at Linden comes pre-polluted with stuff that can
-            # seriously damage 3rd-party builds.  Environmental garbage you can expect
-            # includes:
-            #
-            #    DISTCC_POTENTIAL_HOSTS     arch           root        CXXFLAGS
-            #    DISTCC_LOCATION            top            branch      CC
-            #    DISTCC_HOSTS               build_name     suffix      CXX
-            #    LSDISTCC_ARGS              repo           prefix      CFLAGS
-            #    cxx_version                AUTOBUILD      SIGN        CPPFLAGS
-            #
-            # So, clear out bits that shouldn't affect our configure-directed build
-            # but which do nonetheless.
-            #
-            # unset DISTCC_HOSTS CC CXX CFLAGS CPPFLAGS CXXFLAGS
-
             # Default target per autobuild build --address-size
             opts="${TARGET_OPTS:--m$AUTOBUILD_ADDRSIZE $LL_BUILD_RELEASE}"
             opts="$(remove_cxxstd $opts)"
@@ -134,7 +119,7 @@ pushd "$TOP/$SOURCE_DIR"
                 CPPFLAGS="${CPPFLAGS:-} -I$stage/packages/include/zlib-ng" \
                 LDFLAGS="$opts -L$stage/packages/lib/release" \
                 ./configure --with-python=no --with-pic --with-zlib \
-                --disable-shared --enable-static \
+                --disable-shared --enable-static -with-lzma=no \
                 --prefix="$stage" --libdir="$stage"/lib/release
             make
             make install


### PR DESCRIPTION
libxml2 will automatically pull in lzma if it finds the required headers and libs on the build system. This will lead to implicit link dependencies for all binaries linking to libxml2.a.