### PR TITLE
Change submodule remote to official GNOME libxml2 github mirror to avoid CI being ratelimited

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "libxml2"]
 	path = libxml2
-	url = https://gitlab.gnome.org/GNOME/libxml2.git
+	url = https://github.com/GNOME/libxml2.git


### PR DESCRIPTION
The GHA runners can be rate limited by the gnome gitlab and experience a 500 server response. Change to the official github mirror to work around this issue.