### PR TITLE
Update zlib-ng to 2.2.3-r1 package with zc:wchar_t support

### DIFF
--- a/autobuild.xml
+++ b/autobuild.xml
@@ -23,11 +23,11 @@
             <key>archive</key>
             <map>
               <key>hash</key>
-              <string>4d437afc7fc3988cf0c78ed05853a211cc6bf8b8</string>
+              <string>e363e3b889c52fda7601d7aeaa9832307034651e</string>
               <key>hash_algorithm</key>
               <string>sha1</string>
               <key>url</key>
-              <string>https://github.com/secondlife/3p-zlib-ng/releases/download/v2.2.2-r1/zlib_ng-2.2.2-dev0.gcaa101e.d20241120-darwin64-11943461931.tar.zst</string>
+              <string>https://github.com/secondlife/3p-zlib-ng/releases/download/v2.2.3-r1/zlib_ng-2.2.3-dev0.g8aa13e3.d20250206-darwin64-13183604450.tar.zst</string>
             </map>
             <key>name</key>
             <string>darwin64</string>
@@ -37,11 +37,11 @@
             <key>archive</key>
             <map>
               <key>hash</key>
-              <string>70c1d8728b85481bd42904c1213ed50264e77be1</string>
+              <string>3cdd52f7fb3691789d50f0b40ed6f5642321ff32</string>
               <key>hash_algorithm</key>
               <string>sha1</string>
               <key>url</key>
-              <string>https://github.com/secondlife/3p-zlib-ng/releases/download/v2.2.2-r1/zlib_ng-2.2.2-dev0.gcaa101e.d20241120-linux64-11943461931.tar.zst</string>
+              <string>https://github.com/secondlife/3p-zlib-ng/releases/download/v2.2.3-r1/zlib_ng-2.2.3-dev0.g8aa13e3.d20250206-linux64-13183604450.tar.zst</string>
             </map>
             <key>name</key>
             <string>linux64</string>
@@ -65,18 +65,18 @@
             <key>archive</key>
             <map>
               <key>hash</key>
-              <string>f98c30b20120511ecceab8bf1b5eba048b10aade</string>
+              <string>e802a28139328bb2421ad39e13d996d350d8106d</string>
               <key>hash_algorithm</key>
               <string>sha1</string>
               <key>url</key>
-              <string>https://github.com/secondlife/3p-zlib-ng/releases/download/v2.2.2-r1/zlib_ng-2.2.2-dev0.gcaa101e.d20241120-windows64-11943461931.tar.zst</string>
+              <string>https://github.com/secondlife/3p-zlib-ng/releases/download/v2.2.3-r1/zlib_ng-2.2.3-dev0.g8aa13e3.d20250206-windows64-13183604450.tar.zst</string>
             </map>
             <key>name</key>
             <string>windows64</string>
           </map>
         </map>
         <key>version</key>
-        <string>2.2.2-dev0.gcaa101e.d20241120</string>
+        <string>2.2.3-dev0.g8aa13e3.d20250206</string>
       </map>
     </map>
     <key>package_description</key>


### PR DESCRIPTION
* Update zlib-ng to 2.2.3-r1 package with zc:wchar_t support